### PR TITLE
Remove extension from Link import in index.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -47,9 +47,8 @@ export const getHeaderValue = (property, obj) => {
   return (foundValue === undefined) ? ((property in obj) ? obj[property] : '') : foundValue;
 }
 
-export const elementOrEmpty = (element) => {
+export const elementOrEmpty = (element) => 
   (typeof element === 'undefined' || element === null) ? '' : element;
-};
 
 export const joiner = ((data, separator = ',', enclosingCharacter = '"') => {
   return data

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Download from './components/Download';
-import Link from './components/Link.jsx';
+import Link from './components/Link';
 
 export const CSVDownload = Download;
 export const CSVLink = Link;


### PR DESCRIPTION
I may well have missed something, but I couldn't get this to compile without this change. The babel compiler moves `src/Link.jsx` to `lib/Links.js` but this change is not reflected in the import statement in `lib/index.js`.